### PR TITLE
Adding FUNDING.YML that points to open collective

### DIFF
--- a/.github/FUNDING.YML
+++ b/.github/FUNDING.YML
@@ -1,0 +1,3 @@
+# Funding options
+
+open_collective: tiddlywiki-on-fission


### PR DESCRIPTION
@Jermolene this is another magic file that adds a "sponsor" button to the repo interface that points to the Open Collective.

@walkah just added a version of this to all of our repos.

Should merge cleanly.