### PR TITLE
Update publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,35 +1,35 @@
 name: Publish
 on:
   push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:
   publish_job:
-    name: 'Publish'
+    name: "Publish"
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-      # - name: 🔑 Get npm cache directory
-      #   id: npm-cache-dir
-      #   run: |
-      #     echo "::set-output name=dir::$(npm config get cache)"
-      # - name: 💾 Cache modules
-      #   uses: actions/cache@v2
-      #   id: npm-cache # use this to check for `cache-hit` ==> if: steps.npm-cache.outputs.cache-hit != 'true'
-      #   with:
-      #     path: ${{ steps.npm-cache-dir.outputs.dir }}
-      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-node-
+      - name: 🧱 Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+          cache: "npm"
       - name: 📦 Install packages
         run: npm install
       - name: 🏗 Build assets
         run: npm run build
-      - name: 🚀 Publish to Fission!
+      - name: 🚀 Publish pre-release
+        if: github.ref == 'refs/heads/main'
         uses: fission-suite/publish-action@v1
         with:
+          app_url: tiddlywiki-prerelease.fission.app
+          build_dir: ./app-wiki/output/
+          machine_key: ${{ secrets.MACHINE_KEY }}
+      - name: 🚀 Publish stable
+        if: github.ref == 'refs/heads/latest-stable'
+        uses: fission-suite/publish-action@v1
+        with:
+          app_url: tiddlywiki.fission.app
+          build_dir: ./app-wiki/output/
           machine_key: ${{ secrets.MACHINE_KEY }}

--- a/fission.yaml
+++ b/fission.yaml
@@ -1,3 +1,0 @@
-ignore: []
-url: tiddlywiki.fission.app
-build: ./app-wiki/output/


### PR DESCRIPTION
Tweaked the github action to auto-publish two different branches:
```
main → tiddlywiki-prerelease.fission.app
latest-stable → tiddlywiki.fission.app
```
